### PR TITLE
Update to allow preset loading

### DIFF
--- a/Source/RenderEngine.cpp
+++ b/Source/RenderEngine.cpp
@@ -9,6 +9,15 @@
 */
 
 #include "RenderEngine.h"
+//==============================================================================
+bool RenderEngine::loadPreset (const std::string& path)
+{
+    MemoryBlock mb;
+    File file = File(path);
+    file.loadFileAsData(mb);
+    bool loaded = VSTPluginFormat::loadFromFXBFile (plugin, mb.getData(), mb.getSize());
+    return loaded;
+}
 
 //==============================================================================
 bool RenderEngine::loadPlugin (const std::string& path)
@@ -34,7 +43,6 @@ bool RenderEngine::loadPlugin (const std::string& path)
     String errorMessage;
 
     if (plugin != nullptr) delete plugin;
-
     plugin = pluginFormatManager.createPluginInstance (*pluginDescriptions[0],
                                                        sampleRate,
                                                        bufferSize,
@@ -66,12 +74,16 @@ bool RenderEngine::loadPlugin (const std::string& path)
 void RenderEngine::renderPatch (const uint8  midiNote,
                                 const uint8  midiVelocity,
                                 const double noteLength,
-                                const double renderLength)
+                                const double renderLength,
+                                const bool overridePatch)
 {
     // Get the overriden patch and set the vst parameters with it.
-    PluginPatch overridenPatch = getPatch();
-    for (const auto& parameter : overridenPatch)
-        plugin->setParameter (parameter.first, parameter.second);
+    if (overridePatch)
+    {
+        PluginPatch overridenPatch = getPatch();
+        for (const auto& parameter : overridenPatch)
+            plugin->setParameter (parameter.first, parameter.second);
+    }
 
     // Get the note on midiBuffer.
     MidiMessage onMessage = MidiMessage::noteOn (1,
@@ -364,6 +376,18 @@ void RenderEngine::setPatch (const PluginPatch patch)
         "\n- Current size:  " << currentParameterSize <<
         "\n- Supplied size: " << newPatchParameterSize << std::endl;
     }
+}
+
+//==============================================================================
+float RenderEngine::getParameter (const int parameter)
+{
+    return plugin->getParameter (parameter);
+}
+
+//==============================================================================
+void RenderEngine::setParameter (const int parameter, const float value)
+{
+    plugin->setParameter (parameter, value);
 }
 
 //==============================================================================

--- a/Source/RenderEngine.h
+++ b/Source/RenderEngine.h
@@ -49,17 +49,23 @@ public:
         }
     }
 
+    bool loadPreset (const std::string& path);
 
     bool loadPlugin (const std::string& path);
 
     void setPatch (const PluginPatch patch);
+    
+    float getParameter (const int parameter);
+    
+    void setParameter (const int parameter, const float value);
 
     const PluginPatch getPatch();
 
     void renderPatch (const uint8  midiNote,
                       const uint8  midiVelocity,
                       const double noteLength,
-                      const double renderLength);
+                      const double renderLength,
+                      const bool overridePatch = true);
 
     const MFCCFeatures getMFCCFrames();
 

--- a/Source/source.cpp
+++ b/Source/source.cpp
@@ -118,6 +118,16 @@ namespace wrap
             RenderEngine::setPatch(patch);
         }
 
+        float wrapperGetParameter (int parameter)
+        {
+            return RenderEngine::getParameter(parameter);
+        }
+
+        void wrapperSetParameter (int parameter, float value)
+        {
+            RenderEngine::setParameter(parameter, value);
+        }
+
         boost::python::list wrapperGetPatch()
         {
             return pluginPatchToListOfTuples (RenderEngine::getPatch());
@@ -126,7 +136,8 @@ namespace wrap
         void wrapperRenderPatch (int    midiNote,
                                  int    midiVelocity,
                                  double noteLength,
-                                 double renderLength)
+                                 double renderLength,
+                                 bool overridePatch = true)
         {
             if (midiNote > 255) midiNote = 255;
             if (midiNote < 0) midiNote = 0;
@@ -135,7 +146,8 @@ namespace wrap
             RenderEngine::renderPatch(midiNote,
                                       midiVelocity,
                                       noteLength,
-                                      renderLength);
+                                      renderLength,
+                                      overridePatch);
         }
 
         boost::python::list wrapperGetMFCCFrames()
@@ -191,9 +203,12 @@ BOOST_PYTHON_MODULE(librenderman)
     using namespace wrap;
 
     class_<RenderEngineWrapper>("RenderEngine", init<int, int, int>())
+    .def("load_preset", &RenderEngineWrapper::loadPreset)
     .def("load_plugin", &RenderEngineWrapper::loadPlugin)
-    .def("set_patch", &RenderEngineWrapper::wrapperSetPatch)
     .def("get_patch", &RenderEngineWrapper::wrapperGetPatch)
+    .def("set_patch", &RenderEngineWrapper::wrapperSetPatch)
+    .def("get_parameter", &RenderEngineWrapper::wrapperGetParameter)
+    .def("set_parameter", &RenderEngineWrapper::wrapperSetParameter)
     .def("render_patch", &RenderEngineWrapper::wrapperRenderPatch)
     .def("get_mfcc_frames", &RenderEngineWrapper::wrapperGetMFCCFrames)
     .def("get_plugin_parameter_size", &RenderEngineWrapper::wrapperGetPluginParameterSize)


### PR DESCRIPTION
Right now, RenderMan is configured to render random synth patches - this PR adds in a few methods to load a preset file and set the parameters of the VST plugin from that preset, as well as setting parameters manually. 

In order to make things a little more compatible with the previous API, I've simply added an `overridePatch` parameter to the `renderPatch` method, which allows for the user to call the method with either the manually applied parameter settings or the random "override" patch.

A better API would be to have two separate methods - `renderPatch` (which simply renders audio) and `setRandomPatch` that splits random patch generation away from rendering. I'd be happy to make these changes if this feels like a reasonable direction.